### PR TITLE
Add SubMaterials support and cleanup in sv.lua

### DIFF
--- a/lua/conv/sh.lua
+++ b/lua/conv/sh.lua
@@ -18,7 +18,7 @@ function conv.callNextTick( func, ... )
         func(unpack(argtbl))
     end)
 
-end 
+end
 
 
 -- Do something after a certain amount of ticks/frames
@@ -31,7 +31,7 @@ function conv.callAfterTicks( ticknum, func, ... )
         else
             conv.callAfterTicks( ticknum-1, func, ... )
         end
-        
+
 
     end, ... )
 
@@ -155,7 +155,7 @@ function conv.addFile( File, directory )
 
 	if isServerFile && SERVER then
 		include( directory .. File )
-        return    
+        return
     end
 
     if isClientFile then
@@ -177,7 +177,7 @@ end
 
 function conv.includeDir( directory, skipSubstrs )
     skipSubstrs = skipSubstrs or {}
-    
+
 	directory = directory .. "/"
 
 	local files, directories = file.Find( directory .. "*", "LUA" )
@@ -186,14 +186,14 @@ function conv.includeDir( directory, skipSubstrs )
 	for _, v in ipairs( files ) do
         for _, skipSubstr in ipairs(skipSubstrs) do
             local res = string.find(v, skipSubstr)
-            if res then 
+            if res then
                 bSkip = true
-                break 
+                break
             end
         end
-        if bSkip then 
+        if bSkip then
             bSkip = false
-            continue 
+            continue
         end
 
 		if string.EndsWith( v, ".lua" ) then
@@ -204,14 +204,14 @@ function conv.includeDir( directory, skipSubstrs )
 	for _, v in ipairs( directories ) do
         for _, skipSubstr in ipairs(skipSubstrs) do
             local res = string.find(v, skipSubstr)
-            if res then 
+            if res then
                 bSkip = true
-                break 
+                break
             end
         end
-        if bSkip then 
+        if bSkip then
             bSkip = false
-            continue 
+            continue
         end
 		conv.includeDir( directory .. v, skipSubstrs )
 	end
@@ -238,7 +238,7 @@ function conv.devPrint(...)
                 for _, v in ipairs(table.Pack(...)) do
                     if IsColor(v) then
                         clColStr = "Color("..v.r..", "..v.g..", "..v.b.."), "
-                        continue 
+                        continue
                     end
 
                     clprintStr = clprintStr..tostring(v)
@@ -393,7 +393,7 @@ end
 --]]
 
 
--- "strID"      -   Unique identifier for this text, 
+-- "strID"      -   Unique identifier for this text,
 --                  if another text with this ID is created, the old one will simply be updated
 --                  with the new attributes. ID:s are not synced between client and server.
 -- "pos"        -   The position to display the text at
@@ -424,7 +424,7 @@ function conv.display3DText( strID, pos, fDuration, strText, col, fSize )
     else
         -- Create new text
         text = (SERVER && ents.Create("conv_text")) or (CLIENT && ents.CreateClientside("conv_text"))
-        
+
         if !IsValid(text) then
             error("Failed to create text entity!")
         end
@@ -528,7 +528,7 @@ function conv.getSoundDuration(snd)
 
     local sounddur = SoundDuration( snd )
 	if sounddur then
-		sounddur = math.Round( sounddur * 1000 ) / 1000	
+		sounddur = math.Round( sounddur * 1000 ) / 1000
 	end
 
     return sounddur
@@ -550,7 +550,7 @@ end
 function ENT:CONV_CallNextTick( methodnameorfunc, ... )
     local function func( me, ... )
         if !IsValid(me) then return end
-        
+
         if isstring(methodnameorfunc) then
             me[methodnameorfunc](me, ...)
         elseif isfunction(methodnameorfunc) then
@@ -626,7 +626,7 @@ end
 function ENT:CONV_TimerCreate(name, dur, reps, func, ...)
     local timerName = name..self:EntIndex()
     local args = table.Pack(...)
-    
+
     timer.Create(timerName, dur, reps, function()
         if !IsValid(self) then
             timer.Remove(timerName)
@@ -750,7 +750,7 @@ end
 -- Checks if the provided sequence is valid
 -- 'seq' - The sequence ID or name, can be obtained with ENT:LookupSequence()
 -- Returns true if the sequence is valid, false otherwise
-function ENT:CONV_IsValidSequence( seq )    
+function ENT:CONV_IsValidSequence( seq )
     if !isnumber(seq) then
         seq = self:LookupSequence( seq )
     end
@@ -778,9 +778,9 @@ function NPC:CONV_PlaySequence( seq, speed, cycle, loops, animThink, callback )
     local cycle = cycle || 0
     local loops = loops || 0
 
-    self:SetNPCState( NPC_STATE_SCRIPT )   
-    self:SetSchedule( SCHED_SCENE_GENERIC ) 
-    self:ResetSequenceInfo()  
+    self:SetNPCState( NPC_STATE_SCRIPT )
+    self:SetSchedule( SCHED_SCENE_GENERIC )
+    self:ResetSequenceInfo()
     self:SetSequence( seq )
     self:SetPlaybackRate( speed )
     self:SetCycle( cycle )
@@ -792,12 +792,12 @@ function NPC:CONV_PlaySequence( seq, speed, cycle, loops, animThink, callback )
     local lastTick = CurTime()
 
     self:CONV_AddHook( "Think", function()
-        
+
         if !IsValid(self) then return end
 
         self:SetPlaybackRate( speed )
-        
-        local seqError = self:GetSequence() != seqID     
+
+        local seqError = self:GetSequence() != seqID
 
         if isfunction(animThink) then
 
@@ -818,18 +818,18 @@ function NPC:CONV_PlaySequence( seq, speed, cycle, loops, animThink, callback )
             if ( loops > 0 || loops == -1 ) && !seqError then
 
                 self:ResetSequenceInfo()
-                self:SetCycle( cycle )      
+                self:SetCycle( cycle )
 
                 if isfunction(callback) then callback( loops ) end
 
             elseif ( !loops || loops == 0 || seqError ) then
 
-                self:CONV_StopSequence() 
+                self:CONV_StopSequence()
 
                 if isfunction(callback) then callback( loops, seqError ) end
 
             end
-                  
+
         end
 
     end, name )
@@ -842,8 +842,8 @@ function NPC:CONV_IsPlayingSequence()
 end
 
 -- Stops the currently playing sequence on the NPC
-function NPC:CONV_StopSequence() 
-    self:SetNPCState( NPC_STATE_IDLE )   
+function NPC:CONV_StopSequence()
+    self:SetNPCState( NPC_STATE_IDLE )
     self:ResetSequenceInfo()
     self:CONV_RemoveHook( "Think", "NPCAnimPlayer" .. self:EntIndex() )
 end
@@ -875,7 +875,7 @@ function NPC:CONV_ListConditions()
             table.insert( tab, text )
 
 		end
-		
+
 	end
 
     return tab
@@ -895,22 +895,22 @@ end
 -- 'HITGROUP_GEAR'	    10	Gear. Supposed to be belt area.
 --                          This hitgroup is not present on default player models.
 --                          Alerts NPC, but doesn't do damage or bleed (1/100th damage)
-function NPC:CONV_GetHitGroupBone( hg )	
+function NPC:CONV_GetHitGroupBone( hg )
 	local numHitBoxSets = self:GetHitboxSetCount()
 	if numHitBoxSets then
-		for hboxset = 0, numHitBoxSets - 1 do	
-			local numHitBoxes = self:GetHitBoxCount( hboxset )  
-			for hitbox = 0, numHitBoxes - 1 do	
-				if self:GetHitBoxHitGroup( hitbox, hboxset ) == hg then	
-					local bone = self:GetHitBoxBone( hitbox, hboxset )			
-					if ( !bone || bone < 0 ) then return false end			
+		for hboxset = 0, numHitBoxSets - 1 do
+			local numHitBoxes = self:GetHitBoxCount( hboxset )
+			for hitbox = 0, numHitBoxes - 1 do
+				if self:GetHitBoxHitGroup( hitbox, hboxset ) == hg then
+					local bone = self:GetHitBoxBone( hitbox, hboxset )
+					if ( !bone || bone < 0 ) then return false end
 					local pos, ang = self:GetBonePosition( bone )
-					return pos, ang, bone			
-				end			
-			end		
-		end	
+					return pos, ang, bone
+				end
+			end
+		end
 	end
-	return nil, -1	
+	return nil, -1
 end
 
 
@@ -954,7 +954,7 @@ function conv.tableToString( tbl )
 	local str = "{"
 
 	for k, v in pairs(tbl) do
-        
+
 		if isstring(v) then
 
 			str = str .. string.format( "[%q] = %q,", k, v )
@@ -980,7 +980,7 @@ function conv.tableToString( tbl )
 
 			str = str .. string.format( "[%q] = Angle( %f, %f, %f ),", k, v.p, v.y, v.r )
 
-		elseif IsEntity(v) then
+		elseif isentity(v) then
 
 			str = str .. string.format( "[%q] = Entity( %d ),", k, v:EntIndex() )
 
@@ -997,7 +997,7 @@ function conv.tableToString( tbl )
 	end
 
 	str = str .. "}"
-	
+
 	return str
 end
 
@@ -1005,9 +1005,8 @@ end
 function conv.stringToTable( str )
     local func = CompileString( "return " .. str, "StringToTable", false )
     local tbl = func()
-    
+
     tbl = conv.tablePairsToIPairs( tbl )
 
     return tbl
 end
-


### PR DESCRIPTION
Added support for setting SubMaterials when spawning NPCs. Replaced Ent:Remove() with SafeRemoveEntity in conv.getEntInfo. Removed unused spawnflags helper functions and performed minor whitespace and comment formatting cleanup.